### PR TITLE
Add random seed to formatters

### DIFF
--- a/lib/rspec/teamcity_rspec3.rb
+++ b/lib/rspec/teamcity_rspec3.rb
@@ -35,7 +35,7 @@ module Spec
                                          :example_group_started, :example_group_finished,
                                          :example_started, :example_passed,
                                          :example_pending, :example_failed,
-                                         :dump_summary
+                                         :dump_summary, :seed
 
         RUNNER_ISNT_COMPATIBLE_MESSAGE = "TeamCity Rake Runner Plugin isn't compatible with this RSpec version.\n\n"
         TEAMCITY_FORMATTER_INTERNAL_ERRORS =[]
@@ -268,6 +268,11 @@ module Spec
 
         def close(notification)
           tc_rspec_do_close
+        end
+
+        def seed(notification)
+          return unless notification.seed_used?
+          log notification.fully_formatted
         end
 
         ###########################################################################


### PR DESCRIPTION
Basically just like the upstream:

https://github.com/rspec/rspec-core/blob/a99ff265c6c9d08650acbb34917aabcf1a60c1d4/lib/rspec/core/formatters/base_text_formatter.rb#L15
and
https://github.com/rspec/rspec-core/blob/a99ff265c6c9d08650acbb34917aabcf1a60c1d4/lib/rspec/core/formatters/base_text_formatter.rb#L54-L57

Without it really hard to debug dependency failures on teamcity
